### PR TITLE
feat: add structured framed RPC protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,177 @@
 <img width="1074" src="https://user-images.githubusercontent.com/1169974/55302502-60653980-540f-11e9-94d0-03229ceeac4e.png">
 
+# Synapse P2P
 
-A rapid RPC framework for building p2p networks.
+**Synapse P2P** is a small async Python RPC framework for building peer-to-peer services, local network tools, distributed workers, and lightweight service-to-service APIs.
+
+It gives you a simple decorator-based server API, a built-in async client, structured MsgPack request/response messages, and length-prefixed TCP framing.
+
+```python
+@app.endpoint("sum")
+async def sum_endpoint(a, b):
+    return a + b
+```
+
+```python
+result = await Client("127.0.0.1", 9999).call("sum", 1, 2)
+```
+
+## Features
+
+- **Async TCP RPC** built on `asyncio`
+- **MsgPack serialization** for compact binary messages
+- **Length-prefixed framing** for reliable message boundaries over TCP
+- **Decorator-based endpoints** with `@app.endpoint(...)`
+- **Built-in async client** with request/response handling
+- **Structured responses and errors** via `RPCResponse` and `RPCError`
+- **Positional and keyword arguments** for remote calls
+- **Request IDs** for correlation and future persistent-connection support
+- **Periodic background tasks** with `@app.background(...)`
+- **Serializer abstraction** for custom protocols later
+- **P2P-oriented primitives** such as node identity and XOR-distance helpers
 
 ## Installation
 
-```
+```bash
 pip install synapse-p2p
 ```
 
-Or, for development with [uv](https://docs.astral.sh/uv/):
+For development with [uv](https://docs.astral.sh/uv/):
 
-```
+```bash
 uv sync --group dev
 uv run pytest
 ```
 
-## How does it work?
+## Quickstart
 
-This example registers a public endpoint `sum` that anyone on the network may call, plus a `heartbeat` task running periodically in the background.
+Create a server:
 
 ```python
 from synapse_p2p import Server
 
-app = Server()
-
-
-@app.background(3)
-async def heartbeat():
-    print("Running background task every 3 seconds")
+app = Server(address="127.0.0.1", port=9999)  # or Server() for defaults
 
 
 @app.endpoint("sum")
-async def sum_endpoint(a, b, response, **kwargs):
-    response.write(f"The sum is {a + b}".encode())
+async def sum_endpoint(a: int, b: int) -> int:
+    return a + b
 
 
-app.run()
+if __name__ == "__main__":
+    app.run()
 ```
 
-## Calling an endpoint from a Python client
-
-Synapse uses MsgPack over TCP, so we craft an `RemoteProcedureCall` payload and send it:
+Call it from a client:
 
 ```python
-import socket
+import asyncio
 
-from synapse_p2p import RemoteProcedureCall
+from synapse_p2p import Client
+
+
+async def main() -> None:
+    client = Client("127.0.0.1", 9999)
+    result = await client.call("sum", 1, 2)
+    print(result)
+
+
+asyncio.run(main())
+```
+
+Output:
+
+```text
+3
+```
+
+## Server endpoints
+
+Endpoints are async Python callables registered by name:
+
+```python
+@app.endpoint("greet")
+async def greet(name: str, excited: bool = False) -> str:
+    message = f"Hello, {name}"
+    return message.upper() if excited else message
+```
+
+Call with keyword arguments:
+
+```python
+result = await client.call("greet", "Ada", excited=True)
+```
+
+## Background tasks
+
+Synapse can also run recurring async background jobs alongside your RPC server:
+
+```python
+@app.background(5)
+async def heartbeat():
+    print("still alive")
+```
+
+The task above runs roughly every five seconds. Exceptions are logged and do not stop future runs.
+
+## Structured protocol
+
+Synapse sends length-prefixed MsgPack messages over TCP.
+
+A request looks like:
+
+```python
+RPCRequest(
+    id="request-id",
+    endpoint="sum",
+    args=[1, 2],
+    kwargs={},
+)
+```
+
+A successful response looks like:
+
+```python
+RPCResponse(
+    id="request-id",
+    ok=True,
+    result=3,
+)
+```
+
+An error response looks like:
+
+```python
+RPCResponse(
+    id="request-id",
+    ok=False,
+    error=RPCError(code="bad_request", message="Unregistered endpoint called: nope"),
+)
+```
+
+## Low-level access
+
+Most users should use `Client`, but lower-level message types are exported if you want to build custom transports or tooling:
+
+```python
+from synapse_p2p import RPCError, RPCRequest, RPCResponse, RemoteProcedureCall
+from synapse_p2p.framing import read_frame, write_frame
 from synapse_p2p.serializers import MessagePackRPCSerializer
-
-with socket.create_connection(("127.0.0.1", 9999)) as sock:
-    sock.sendall(
-        MessagePackRPCSerializer.serialize(
-            RemoteProcedureCall(endpoint="sum", args=[1, 2])
-        )
-    )
-    data = sock.recv(1024)
-
-print(f"Received:\n{data.decode()}")
 ```
 
-```
-Received:
-The sum is 3
-```
+`RemoteProcedureCall` is kept as a backwards-compatible alias for `RPCRequest`.
+
+## Project status
+
+Synapse is intentionally small and evolving. The current focus is a clean async RPC foundation. Future P2P-oriented work may include:
+
+- Peer discovery
+- Persistent connections
+- Routing tables / Kademlia-style node lookup
+- Handshakes and node capabilities
+- Authenticated or encrypted messages
+- Broadcast and gossip primitives
+
+## Keywords
+
+Python RPC, asyncio RPC, peer-to-peer Python, P2P networking, MsgPack RPC, TCP RPC, async microservices, distributed workers, service-to-service communication.

--- a/example_client.py
+++ b/example_client.py
@@ -1,18 +1,12 @@
-import socket
+import asyncio
 
-from synapse_p2p import RemoteProcedureCall
-from synapse_p2p.serializers import MessagePackRPCSerializer
+from synapse_p2p import Client
 
 
-def main() -> None:
-    with socket.create_connection(("127.0.0.1", 9999)) as sock:
-        sock.sendall(
-            MessagePackRPCSerializer.serialize(RemoteProcedureCall(endpoint="sum", args=[1, 2]))
-        )
-        data = sock.recv(1024)
-
-    print(f"Received:\n{data.decode()}")
+async def main() -> None:
+    result = await Client("127.0.0.1", 9999).call("sum", 1, 2)
+    print(f"Received: {result}")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/example_server.py
+++ b/example_server.py
@@ -9,8 +9,8 @@ async def heartbeat():
 
 
 @app.endpoint("sum")
-async def sum_endpoint(a, b, response, **kwargs):
-    response.write(f"The sum is {a + b}".encode())
+async def sum_endpoint(a, b):
+    return a + b
 
 
 if __name__ == "__main__":

--- a/synapse_p2p/__init__.py
+++ b/synapse_p2p/__init__.py
@@ -1,4 +1,10 @@
-__version__ = "0.1.4"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("synapse-p2p")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
 __logo__ = f"""
 \033[32m
 ███████╗██╗   ██╗███╗   ██╗ █████╗ ██████╗ ███████╗███████╗
@@ -11,7 +17,17 @@ __logo__ = f"""
 \033[33m⚡ \033[35msynapse \033[36m{__version__}\033[0m
 """
 
-from synapse_p2p.messages import RemoteProcedureCall
+from synapse_p2p.client import Client
+from synapse_p2p.messages import RemoteProcedureCall, RPCError, RPCRequest, RPCResponse
 from synapse_p2p.server import Server
 
-__all__ = ["RemoteProcedureCall", "Server", "__logo__", "__version__"]
+__all__ = [
+    "Client",
+    "RPCError",
+    "RPCRequest",
+    "RPCResponse",
+    "RemoteProcedureCall",
+    "Server",
+    "__logo__",
+    "__version__",
+]

--- a/synapse_p2p/client.py
+++ b/synapse_p2p/client.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from synapse_p2p.framing import read_frame, write_frame
+from synapse_p2p.messages import RPCRequest, RPCResponse
+from synapse_p2p.serializers import BaseRPCSerializer, MessagePackRPCSerializer
+from synapse_p2p.utils import random_hash
+
+
+class Client:
+    def __init__(
+        self,
+        address: str = "127.0.0.1",
+        port: int = 9999,
+        serializer_class: type[BaseRPCSerializer] = MessagePackRPCSerializer,
+        max_download_size: int = 4096,
+        timeout: float | None = 30,
+    ) -> None:
+        self.address = address
+        self.port = port
+        self.serializer_class = serializer_class
+        self.max_download_size = max_download_size
+        self.timeout = timeout
+
+    async def call(self, endpoint: str, *args, **kwargs):
+        request = RPCRequest(id=random_hash(), endpoint=endpoint, args=list(args), kwargs=kwargs)
+        reader, writer = await asyncio.open_connection(self.address, self.port)
+        try:
+            await write_frame(writer, self.serializer_class.serialize(request))
+            payload = await asyncio.wait_for(
+                read_frame(reader, self.max_download_size), self.timeout
+            )
+            response = self.serializer_class.deserialize(payload)
+            if not isinstance(response, RPCResponse):
+                raise RuntimeError("server returned a non-response message")
+            if not response.ok:
+                message = response.error.message if response.error else "RPC call failed"
+                raise RuntimeError(message)
+            return response.result
+        finally:
+            writer.close()
+            await writer.wait_closed()

--- a/synapse_p2p/framing.py
+++ b/synapse_p2p/framing.py
@@ -1,0 +1,26 @@
+import asyncio
+import struct
+
+from synapse_p2p.exceptions import InvalidMessageError
+
+_HEADER = struct.Struct("!I")
+
+
+async def read_frame(reader: asyncio.StreamReader, max_size: int) -> bytes:
+    try:
+        header = await reader.readexactly(_HEADER.size)
+        (size,) = _HEADER.unpack(header)
+        if size > max_size:
+            raise InvalidMessageError(f"frame too large: {size} > {max_size}")
+        return await reader.readexactly(size)
+    except asyncio.IncompleteReadError as e:
+        raise InvalidMessageError("incomplete frame") from e
+
+
+def encode_frame(payload: bytes) -> bytes:
+    return _HEADER.pack(len(payload)) + payload
+
+
+async def write_frame(writer: asyncio.StreamWriter, payload: bytes) -> None:
+    writer.write(encode_frame(payload))
+    await writer.drain()

--- a/synapse_p2p/messages.py
+++ b/synapse_p2p/messages.py
@@ -1,8 +1,30 @@
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(slots=True)
-class RemoteProcedureCall:
+class RPCError:
+    code: str
+    message: str
+
+
+@dataclass(slots=True)
+class RPCRequest:
     endpoint: str
+    id: str = ""
     args: list[Any] = field(default_factory=list)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    type: Literal["request"] = "request"
+
+
+@dataclass(slots=True)
+class RPCResponse:
+    id: str
+    ok: bool
+    result: Any | None = None
+    error: RPCError | None = None
+    type: Literal["response"] = "response"
+
+
+# Backwards-compatible alias for the original public request type.
+RemoteProcedureCall = RPCRequest

--- a/synapse_p2p/serializers.py
+++ b/synapse_p2p/serializers.py
@@ -1,32 +1,63 @@
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 
 import msgpack
 from loguru import logger
 
 from synapse_p2p.exceptions import InvalidMessageError
-from synapse_p2p.messages import RemoteProcedureCall
+from synapse_p2p.messages import RPCError, RPCRequest, RPCResponse
+
+RPCMessage = RPCRequest | RPCResponse
 
 
 class BaseRPCSerializer:
     @classmethod
-    def serialize(cls, outgoing: RemoteProcedureCall) -> bytes:
+    def serialize(cls, outgoing: RPCMessage) -> bytes:
         raise NotImplementedError
 
     @classmethod
-    def deserialize(cls, incoming: bytes) -> RemoteProcedureCall:
+    def deserialize(cls, incoming: bytes) -> RPCMessage:
         raise NotImplementedError
 
 
 class MessagePackRPCSerializer(BaseRPCSerializer):
     @classmethod
-    def serialize(cls, outgoing: RemoteProcedureCall) -> bytes:
-        return msgpack.packb(asdict(outgoing))
+    def serialize(cls, outgoing: RPCMessage) -> bytes:
+        if not is_dataclass(outgoing):
+            raise TypeError("RPC messages must be dataclass instances")
+        return msgpack.packb(asdict(outgoing), use_bin_type=True)
 
     @classmethod
-    def deserialize(cls, incoming: bytes) -> RemoteProcedureCall:
+    def deserialize(cls, incoming: bytes) -> RPCMessage:
         try:
             payload = msgpack.unpackb(incoming, raw=False)
-            return RemoteProcedureCall(**payload)
-        except (TypeError, ValueError, msgpack.UnpackException) as e:
+            if not isinstance(payload, dict):
+                raise TypeError("payload must be a map")
+
+            message_type = payload.get("type", "request")
+            if message_type == "request":
+                unknown = set(payload) - {"type", "id", "endpoint", "args", "kwargs"}
+                if unknown:
+                    raise TypeError(f"unknown request fields: {sorted(unknown)}")
+                return RPCRequest(
+                    id=str(payload.get("id", "")),
+                    endpoint=payload["endpoint"],
+                    args=list(payload.get("args", [])),
+                    kwargs=dict(payload.get("kwargs", {})),
+                )
+
+            if message_type == "response":
+                unknown = set(payload) - {"type", "id", "ok", "result", "error"}
+                if unknown:
+                    raise TypeError(f"unknown response fields: {sorted(unknown)}")
+                error = payload.get("error")
+                return RPCResponse(
+                    id=str(payload.get("id", "")),
+                    ok=bool(payload["ok"]),
+                    result=payload.get("result"),
+                    error=RPCError(**error) if error is not None else None,
+                )
+
+            raise TypeError(f"unknown RPC message type: {message_type}")
+        except (KeyError, TypeError, ValueError, msgpack.UnpackException) as e:
             logger.error("Could not deserialize payload: {!r}", incoming)
             raise InvalidMessageError(str(e)) from e

--- a/synapse_p2p/server.py
+++ b/synapse_p2p/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import inspect
 from collections.abc import Callable
 
 from loguru import logger
@@ -7,7 +8,8 @@ from loguru import logger
 from synapse_p2p import __logo__
 from synapse_p2p.background import BackgroundTaskHandler
 from synapse_p2p.exceptions import InvalidMessageError
-from synapse_p2p.messages import RemoteProcedureCall
+from synapse_p2p.framing import read_frame, write_frame
+from synapse_p2p.messages import RPCError, RPCRequest, RPCResponse
 from synapse_p2p.serializers import BaseRPCSerializer, MessagePackRPCSerializer
 from synapse_p2p.types import BackgroundTask, Node, build_node_from_peer_name
 
@@ -33,29 +35,51 @@ class Server:
         with contextlib.suppress(KeyboardInterrupt):
             asyncio.run(self.serve())
 
+    async def _dispatch(self, rpc: RPCRequest, node: Node):
+        endpoint = self.endpoint_directory.get(rpc.endpoint)
+        if endpoint is None:
+            raise InvalidMessageError(f"Unregistered endpoint called: {rpc.endpoint}")
+
+        signature = inspect.signature(endpoint)
+        injected = {"rpc": rpc, "node": node}
+        kwargs = dict(rpc.kwargs)
+        for name, value in injected.items():
+            if name in signature.parameters:
+                kwargs[name] = value
+
+        return await endpoint(*rpc.args, **kwargs)
+
     async def handle_data(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        """Receive data, dispatch to registered endpoint, write response."""
+        """Receive a framed request, dispatch it, and write a framed response."""
         node: Node = build_node_from_peer_name(writer.get_extra_info("peername"))
         logger.debug("Talking to Node {} @ {}:{}", node.identifier, node.ip, node.port)
-
-        data = await reader.read(self.max_upload_size)
+        request_id = ""
 
         try:
-            rpc: RemoteProcedureCall = self.serializer_class.deserialize(data)
+            data = await read_frame(reader, self.max_upload_size)
+            rpc = self.serializer_class.deserialize(data)
+            if not isinstance(rpc, RPCRequest):
+                raise InvalidMessageError("expected request message")
+            request_id = rpc.id
 
-            endpoint = self.endpoint_directory.get(rpc.endpoint)
-            if endpoint is None:
-                raise InvalidMessageError(f"Unregistered endpoint called: {rpc.endpoint}")
-
-            await endpoint(*rpc.args, rpc=rpc, node=node, response=writer)
-        except InvalidMessageError:
-            logger.debug("Invalid message from {}:{}: {!r}", node.ip, node.port, data)
-            writer.write(b"400")
-        except Exception:
+            result = await self._dispatch(rpc, node)
+            response = RPCResponse(id=request_id, ok=True, result=result)
+        except InvalidMessageError as e:
+            logger.debug("Invalid message from {}:{}: {}", node.ip, node.port, e)
+            response = RPCResponse(
+                id=request_id,
+                ok=False,
+                error=RPCError(code="bad_request", message=str(e)),
+            )
+        except Exception as e:
             logger.exception("Endpoint raised while handling {}:{}", node.ip, node.port)
-            writer.write(b"500")
+            response = RPCResponse(
+                id=request_id,
+                ok=False,
+                error=RPCError(code="internal_error", message=str(e)),
+            )
 
-        await writer.drain()
+        await write_frame(writer, self.serializer_class.serialize(response))
         logger.debug("Closing connection to {}:{}", node.ip, node.port)
         writer.close()
         await writer.wait_closed()

--- a/synapse_p2p/tests/test_framing.py
+++ b/synapse_p2p/tests/test_framing.py
@@ -1,0 +1,32 @@
+import asyncio
+import struct
+
+import pytest
+
+from synapse_p2p.exceptions import InvalidMessageError
+from synapse_p2p.framing import encode_frame, read_frame
+
+
+def test_encode_frame_prefixes_payload_length():
+    payload = b"hello"
+    assert encode_frame(payload) == struct.pack("!I", len(payload)) + payload
+
+
+@pytest.mark.asyncio
+async def test_read_frame_rejects_oversized_frame():
+    reader = asyncio.StreamReader()
+    reader.feed_data(struct.pack("!I", 10) + b"0123456789")
+    reader.feed_eof()
+
+    with pytest.raises(InvalidMessageError, match="frame too large"):
+        await read_frame(reader, max_size=5)
+
+
+@pytest.mark.asyncio
+async def test_read_frame_rejects_incomplete_frame():
+    reader = asyncio.StreamReader()
+    reader.feed_data(struct.pack("!I", 10) + b"short")
+    reader.feed_eof()
+
+    with pytest.raises(InvalidMessageError, match="incomplete frame"):
+        await read_frame(reader, max_size=20)

--- a/synapse_p2p/tests/test_protocol.py
+++ b/synapse_p2p/tests/test_protocol.py
@@ -1,0 +1,41 @@
+import msgpack
+import pytest
+
+from synapse_p2p import RemoteProcedureCall
+from synapse_p2p.exceptions import InvalidMessageError
+from synapse_p2p.messages import RPCError, RPCRequest, RPCResponse
+from synapse_p2p.serializers import MessagePackRPCSerializer
+
+
+def test_remote_procedure_call_alias_still_constructs_request():
+    rpc = RemoteProcedureCall(endpoint="ping")
+    assert isinstance(rpc, RPCRequest)
+    assert rpc.endpoint == "ping"
+
+
+def test_response_roundtrip():
+    response = RPCResponse(id="abc", ok=True, result={"nested": [1, 2, 3]})
+    restored = MessagePackRPCSerializer.deserialize(MessagePackRPCSerializer.serialize(response))
+    assert restored == response
+
+
+def test_error_response_roundtrip():
+    response = RPCResponse(
+        id="abc",
+        ok=False,
+        error=RPCError(code="bad_request", message="nope"),
+    )
+    restored = MessagePackRPCSerializer.deserialize(MessagePackRPCSerializer.serialize(response))
+    assert restored == response
+
+
+def test_deserialize_rejects_unknown_response_fields():
+    payload = msgpack.packb({"type": "response", "id": "abc", "ok": True, "bogus": True})
+    with pytest.raises(InvalidMessageError):
+        MessagePackRPCSerializer.deserialize(payload)
+
+
+def test_deserialize_rejects_non_map_payload():
+    payload = msgpack.packb(["not", "a", "map"])
+    with pytest.raises(InvalidMessageError):
+        MessagePackRPCSerializer.deserialize(payload)

--- a/synapse_p2p/tests/test_server.py
+++ b/synapse_p2p/tests/test_server.py
@@ -2,7 +2,9 @@ import asyncio
 
 import pytest
 
-from synapse_p2p.messages import RemoteProcedureCall
+from synapse_p2p.client import Client
+from synapse_p2p.framing import read_frame, write_frame
+from synapse_p2p.messages import RemoteProcedureCall, RPCError, RPCRequest, RPCResponse
 from synapse_p2p.serializers import MessagePackRPCSerializer
 from synapse_p2p.server import Server
 
@@ -33,19 +35,24 @@ def test_background_decorator_registers_task(server):
     assert server.background_executor.tasks[0].period == 5
 
 
-async def _send_rpc(server: Server, rpc: RemoteProcedureCall) -> bytes:
+async def _send_message(server: Server, message) -> RPCResponse:
     tcp = await asyncio.start_server(server.handle_data, server.address, server.port)
     host, port = tcp.sockets[0].getsockname()[:2]
 
     async with tcp:
         reader, writer = await asyncio.open_connection(host, port)
-        writer.write(MessagePackRPCSerializer.serialize(rpc))
-        await writer.drain()
-        data = await reader.read(1024)
+        await write_frame(writer, MessagePackRPCSerializer.serialize(message))
+        data = await read_frame(reader, 4096)
         writer.close()
         await writer.wait_closed()
 
-    return data
+    response = MessagePackRPCSerializer.deserialize(data)
+    assert isinstance(response, RPCResponse)
+    return response
+
+
+async def _send_rpc(server: Server, rpc: RemoteProcedureCall) -> RPCResponse:
+    return await _send_message(server, rpc)
 
 
 @pytest.mark.asyncio
@@ -53,27 +60,123 @@ async def test_server_round_trip_over_tcp():
     server = Server(address="127.0.0.1", port=0)
 
     @server.endpoint("sum")
-    async def _sum(a, b, response, **kwargs):
-        response.write(f"{a + b}".encode())
+    async def _sum(a, b):
+        return a + b
 
-    data = await _send_rpc(server, RemoteProcedureCall(endpoint="sum", args=[2, 3]))
-    assert data == b"5"
+    response = await _send_rpc(server, RPCRequest(id="abc", endpoint="sum", args=[2, 3]))
+    assert response == RPCResponse(id="abc", ok=True, result=5)
 
 
 @pytest.mark.asyncio
-async def test_unknown_endpoint_responds_400():
+async def test_client_call_over_tcp():
     server = Server(address="127.0.0.1", port=0)
-    data = await _send_rpc(server, RemoteProcedureCall(endpoint="nope"))
-    assert data == b"400"
+
+    @server.endpoint("sum")
+    async def _sum(a, b, scale=1):
+        return (a + b) * scale
+
+    tcp = await asyncio.start_server(server.handle_data, server.address, server.port)
+    host, port = tcp.sockets[0].getsockname()[:2]
+
+    async with tcp:
+        result = await Client(host, port).call("sum", 2, 3, scale=2)
+
+    assert result == 10
 
 
 @pytest.mark.asyncio
-async def test_endpoint_exception_responds_500_without_killing_server():
+async def test_unknown_endpoint_responds_bad_request():
+    server = Server(address="127.0.0.1", port=0)
+    response = await _send_rpc(server, RPCRequest(id="abc", endpoint="nope"))
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "bad_request"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_exception_responds_internal_error_without_killing_server():
     server = Server(address="127.0.0.1", port=0)
 
     @server.endpoint("boom")
     async def boom(**kwargs):
         raise RuntimeError("kaboom")
 
-    data = await _send_rpc(server, RemoteProcedureCall(endpoint="boom"))
-    assert data == b"500"
+    response = await _send_rpc(server, RPCRequest(id="abc", endpoint="boom"))
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "internal_error"
+
+
+@pytest.mark.asyncio
+async def test_server_injects_rpc_and_node_when_requested():
+    server = Server(address="127.0.0.1", port=0)
+
+    @server.endpoint("inspect")
+    async def inspect_context(rpc, node):
+        return {"request_id": rpc.id, "node_id_length": len(node.identifier)}
+
+    response = await _send_rpc(server, RPCRequest(id="abc", endpoint="inspect"))
+    assert response.ok is True
+    assert response.result == {"request_id": "abc", "node_id_length": 8}
+
+
+@pytest.mark.asyncio
+async def test_server_rejects_response_sent_as_request():
+    server = Server(address="127.0.0.1", port=0)
+    response = await _send_message(server, RPCResponse(id="abc", ok=True, result="wrong-way"))
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.code == "bad_request"
+
+
+@pytest.mark.asyncio
+async def test_client_raises_on_rpc_error():
+    server = Server(address="127.0.0.1", port=0)
+
+    tcp = await asyncio.start_server(server.handle_data, server.address, server.port)
+    host, port = tcp.sockets[0].getsockname()[:2]
+
+    async with tcp:
+        with pytest.raises(RuntimeError, match="Unregistered endpoint"):
+            await Client(host, port).call("missing")
+
+
+@pytest.mark.asyncio
+async def test_client_raises_on_non_response_payload():
+    async def handle(reader, writer):
+        await read_frame(reader, 4096)
+        await write_frame(
+            writer,
+            MessagePackRPCSerializer.serialize(RPCRequest(id="abc", endpoint="not-response")),
+        )
+        writer.close()
+        await writer.wait_closed()
+
+    tcp = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = tcp.sockets[0].getsockname()[:2]
+
+    async with tcp:
+        with pytest.raises(RuntimeError, match="non-response"):
+            await Client(host, port).call("anything")
+
+
+@pytest.mark.asyncio
+async def test_client_timeout():
+    async def handle(reader, writer):
+        await read_frame(reader, 4096)
+        await asyncio.sleep(0.05)
+        writer.close()
+        await writer.wait_closed()
+
+    tcp = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = tcp.sockets[0].getsockname()[:2]
+
+    async with tcp:
+        with pytest.raises(TimeoutError):
+            await Client(host, port, timeout=0.01).call("slow")
+
+
+def test_response_error_shape():
+    response = RPCResponse(id="abc", ok=False, error=RPCError("code", "message"))
+    assert response.error is not None
+    assert response.error.code == "code"


### PR DESCRIPTION
- Add RPCRequest, RPCResponse, and RPCError message types
- Add length-prefixed MsgPack framing
- Add async Client with request/response handling
- Update Server to return structured responses from endpoint results
- Support kwargs and request IDs
- Keep RemoteProcedureCall as a backwards-compatible alias
- Load package version dynamically from metadata
- Update examples, README, and tests