### PR TITLE
feat: Synapse agent network substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,38 @@
 
 # Synapse P2P
 
-**Synapse P2P** is a small async Python RPC framework for building peer-to-peer services, local network tools, distributed workers, and lightweight service-to-service APIs.
+**A network substrate for Python agents.**
 
-It gives you a simple decorator-based server API, a built-in async client, structured MsgPack request/response messages, and length-prefixed TCP framing.
+Synapse P2P is a tiny async RPC, discovery, and capability-publishing layer for building agent-to-agent networks, local agent swarms, distributed tools, peer-to-peer services, and lightweight service meshes.
+
+It is designed to be useful to both humans and LLM agents:
+
+- Humans get a simple Python API.
+- Agents get discoverable methods, published capabilities, structured request/response messages, and machine-readable metadata.
 
 ```python
 @app.endpoint("sum")
-async def sum_endpoint(a, b):
+async def sum_endpoint(a: int, b: int) -> int:
     return a + b
 ```
 
 ```python
 result = await Client("127.0.0.1", 9999).call("sum", 1, 2)
 ```
+
+## Why Synapse?
+
+LLM agents need a way to find each other, ask what each other can do, and delegate work over a small, predictable protocol.
+
+Synapse provides the substrate for that:
+
+- **RPC**: call remote Python functions over TCP.
+- **Discovery**: inspect published methods and agent capabilities.
+- **Agent identity**: expose role, description, and capabilities.
+- **Delegation**: send tasks to another agent through `_agent.ask`.
+- **Structured protocol**: MsgPack request/response envelopes with request IDs and errors.
+
+Think of it as a minimal network layer for agentic systems — not a framework that decides how agents think, but a substrate they can use to connect.
 
 ## Features
 
@@ -26,6 +45,9 @@ result = await Client("127.0.0.1", 9999).call("sum", 1, 2)
 - **Structured responses and errors** via `RPCResponse` and `RPCError`
 - **Positional and keyword arguments** for remote calls
 - **Request IDs** for correlation and future persistent-connection support
+- **Published method discovery** via `_synapse.methods`
+- **Agent metadata discovery** via `_agent.info` and `_agent.capabilities`
+- **Agent task delegation** via `_agent.ask`
 - **Periodic background tasks** with `@app.background(...)`
 - **Serializer abstraction** for custom protocols later
 - **P2P-oriented primitives** such as node identity and XOR-distance helpers
@@ -41,9 +63,11 @@ For development with [uv](https://docs.astral.sh/uv/):
 ```bash
 uv sync --group dev
 uv run pytest
+uv run ruff check .
+uv run pyrefly check
 ```
 
-## Quickstart
+## Quickstart: RPC server and client
 
 Create a server:
 
@@ -53,7 +77,7 @@ from synapse_p2p import Server
 app = Server(address="127.0.0.1", port=9999)  # or Server() for defaults
 
 
-@app.endpoint("sum")
+@app.endpoint("sum", description="Add two numbers")
 async def sum_endpoint(a: int, b: int) -> int:
     return a + b
 
@@ -85,22 +109,203 @@ Output:
 3
 ```
 
-## Server endpoints
+## Quickstart: agent node
 
-Endpoints are async Python callables registered by name:
-
-```python
-@app.endpoint("greet")
-async def greet(name: str, excited: bool = False) -> str:
-    message = f"Hello, {name}"
-    return message.upper() if excited else message
-```
-
-Call with keyword arguments:
+An `AgentNode` is a Synapse server that publishes agent metadata and accepts delegated work.
 
 ```python
-result = await client.call("greet", "Ada", excited=True)
+from synapse_p2p import AgentNode
+
+agent = AgentNode(
+    name="Reviewer",
+    role="reviewer",
+    description="Reviews Python code and suggests tests.",
+    capabilities=["python", "code-review", "pytest"],
+)
+
+
+@agent.task_handler
+async def handle_task(task: str, context: dict):
+    return {
+        "status": "done",
+        "result": f"Reviewed task: {task}",
+        "context_keys": list(context),
+    }
+
+
+agent.run()
 ```
+
+Another agent or client can inspect it:
+
+```python
+info = await client.call("_agent.info")
+capabilities = await client.call("_agent.capabilities")
+```
+
+And delegate work:
+
+```python
+result = await client.call(
+    "_agent.ask",
+    "Review this pull request",
+    context={"files": ["server.py", "client.py"]},
+)
+```
+
+## Built-in discovery endpoints
+
+Synapse reserves `_synapse.*` for substrate-level metadata.
+
+### `_synapse.ping`
+
+Health check:
+
+```python
+await client.call("_synapse.ping")
+# "pong"
+```
+
+### `_synapse.methods`
+
+Returns published RPC methods:
+
+```python
+await client.call("_synapse.methods")
+```
+
+Example response:
+
+```python
+[
+    {
+        "name": "sum",
+        "publish": True,
+        "description": "Add two numbers",
+    }
+]
+```
+
+Endpoints are published by default:
+
+```python
+@app.endpoint("image.resize", description="Resize an image")
+async def resize_image(...):
+    ...
+```
+
+Private endpoints can opt out:
+
+```python
+@app.endpoint("admin.restart", publish=False)
+async def restart():
+    ...
+```
+
+## Built-in agent endpoints
+
+Synapse reserves `_agent.*` for agent-level metadata and task delegation.
+
+### `_agent.info`
+
+Returns agent identity:
+
+```python
+{
+    "name": "Reviewer",
+    "role": "reviewer",
+    "description": "Reviews Python code and suggests tests.",
+    "capabilities": ["python", "code-review", "pytest"],
+}
+```
+
+### `_agent.capabilities`
+
+Returns machine-readable capability descriptors:
+
+```python
+[
+    {
+        "name": "code-review",
+        "description": "Review Python code for correctness and maintainability.",
+        "input_schema": {},
+        "output_schema": {},
+    }
+]
+```
+
+Capabilities can be strings or explicit descriptors:
+
+```python
+from synapse_p2p import AgentCapability, AgentNode
+
+agent = AgentNode(
+    name="Researcher",
+    role="researcher",
+    capabilities=[
+        AgentCapability(
+            name="web-research",
+            description="Find and summarize evidence from the web.",
+            input_schema={"query": "string"},
+            output_schema={"summary": "string", "sources": "array"},
+        )
+    ],
+)
+```
+
+### `_agent.ask`
+
+Delegates a task to the agent's registered task handler:
+
+```python
+await client.call(
+    "_agent.ask",
+    "Find bugs in this module",
+    context={"code": "..."},
+)
+```
+
+The task handler receives:
+
+```python
+async def handle_task(task: str, context: dict):
+    ...
+```
+
+## Patterns for LLM agents
+
+### 1. Discover a peer
+
+```python
+info = await client.call("_agent.info")
+methods = await client.call("_synapse.methods")
+capabilities = await client.call("_agent.capabilities")
+```
+
+### 2. Select a peer by capability
+
+```python
+if "code-review" in info["capabilities"]:
+    result = await client.call("_agent.ask", "Review this diff", context={"diff": diff})
+```
+
+### 3. Publish tools as RPC methods
+
+```python
+@app.endpoint("filesystem.search", description="Search files by regex")
+async def search_files(pattern: str) -> list[str]:
+    ...
+```
+
+### 4. Hide dangerous tools
+
+```python
+@app.endpoint("shell.exec", publish=False)
+async def shell_exec(command: str) -> str:
+    ...
+```
+
+Private methods are still callable if known, but they are not advertised by `_synapse.methods`.
 
 ## Server lifecycle
 
@@ -116,7 +321,7 @@ finally:
 
 ## Background tasks
 
-Synapse can also run recurring async background jobs alongside your RPC server:
+Synapse can run recurring async background jobs alongside your RPC server:
 
 ```python
 @app.background(5)
@@ -175,10 +380,12 @@ from synapse_p2p.serializers import MessagePackRPCSerializer
 
 ## Project status
 
-Synapse is intentionally small and evolving. The current focus is a clean async RPC foundation. Future P2P-oriented work may include:
+Synapse is intentionally small and evolving. The current focus is a clean async RPC and agent substrate. Future work may include:
 
-- Peer discovery
-- Persistent connections
+- Peer discovery and bootstrap peer exchange
+- Agent-to-agent network discovery
+- Long-running jobs for agent tasks
+- Persistent connections and streaming events
 - Routing tables / Kademlia-style node lookup
 - Handshakes and node capabilities
 - Authenticated or encrypted messages
@@ -186,4 +393,4 @@ Synapse is intentionally small and evolving. The current focus is a clean async 
 
 ## Keywords
 
-Python RPC, asyncio RPC, peer-to-peer Python, P2P networking, MsgPack RPC, TCP RPC, async microservices, distributed workers, service-to-service communication.
+Python agent substrate, agent-to-agent networking, LLM agent RPC, multi-agent systems, agent discovery, capability discovery, Python RPC, asyncio RPC, peer-to-peer Python, P2P networking, MsgPack RPC, TCP RPC, async microservices, distributed agents, distributed workers, service-to-service communication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "synapse-p2p"
 dynamic = ["version"]
-description = "A rapid RPC framework for building p2p networks"
+description = "A network substrate for Python agents"
 readme = "README.md"
 authors = [{ name = "Daniel van Flymen", email = "vanflymen@gmail.com" }]
 requires-python = ">=3.10"

--- a/synapse_p2p/__init__.py
+++ b/synapse_p2p/__init__.py
@@ -17,11 +17,14 @@ __logo__ = f"""
 \033[33m⚡ \033[35msynapse \033[36m{__version__}\033[0m
 """
 
+from synapse_p2p.agent import AgentCapability, AgentNode
 from synapse_p2p.client import Client
 from synapse_p2p.messages import RemoteProcedureCall, RPCError, RPCRequest, RPCResponse
 from synapse_p2p.server import Server
 
 __all__ = [
+    "AgentCapability",
+    "AgentNode",
     "Client",
     "RPCError",
     "RPCRequest",

--- a/synapse_p2p/agent.py
+++ b/synapse_p2p/agent.py
@@ -1,0 +1,80 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from synapse_p2p.server import Server
+
+AgentTaskHandler = Callable[[str, dict[str, Any]], Awaitable[Any]]
+
+
+@dataclass(slots=True)
+class AgentCapability:
+    name: str
+    description: str = ""
+    input_schema: dict[str, Any] = field(default_factory=dict)
+    output_schema: dict[str, Any] = field(default_factory=dict)
+
+
+class AgentNode(Server):
+    def __init__(
+        self,
+        *,
+        name: str,
+        role: str,
+        description: str = "",
+        capabilities: list[str | AgentCapability] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.name = name
+        self.role = role
+        self.description = description
+        self.capabilities = [self._normalize_capability(c) for c in capabilities or []]
+        self._task_handler: AgentTaskHandler | None = None
+        self._register_agent_endpoints()
+
+    def _normalize_capability(self, capability: str | AgentCapability) -> AgentCapability:
+        if isinstance(capability, str):
+            return AgentCapability(name=capability)
+        return capability
+
+    def capability(
+        self,
+        name: str,
+        *,
+        description: str = "",
+        input_schema: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
+    ) -> AgentCapability:
+        capability = AgentCapability(
+            name=name,
+            description=description,
+            input_schema=input_schema or {},
+            output_schema=output_schema or {},
+        )
+        self.capabilities.append(capability)
+        return capability
+
+    def task_handler(self, wrapped: AgentTaskHandler) -> AgentTaskHandler:
+        self._task_handler = wrapped
+        return wrapped
+
+    def _register_agent_endpoints(self) -> None:
+        @self.endpoint("_agent.info", publish=False)
+        async def agent_info() -> dict[str, Any]:
+            return {
+                "name": self.name,
+                "role": self.role,
+                "description": self.description,
+                "capabilities": [capability.name for capability in self.capabilities],
+            }
+
+        @self.endpoint("_agent.capabilities", publish=False)
+        async def agent_capabilities() -> list[dict[str, Any]]:
+            return [asdict(capability) for capability in self.capabilities]
+
+        @self.endpoint("_agent.ask", publish=False)
+        async def agent_ask(task: str, context: dict[str, Any] | None = None) -> Any:
+            if self._task_handler is None:
+                raise RuntimeError("agent has no task handler")
+            return await self._task_handler(task, context or {})

--- a/synapse_p2p/server.py
+++ b/synapse_p2p/server.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import inspect
 from collections.abc import Callable
+from dataclasses import asdict, dataclass
 
 from loguru import logger
 
@@ -12,6 +13,13 @@ from synapse_p2p.framing import read_frame, write_frame
 from synapse_p2p.messages import RPCError, RPCRequest, RPCResponse
 from synapse_p2p.serializers import BaseRPCSerializer, MessagePackRPCSerializer
 from synapse_p2p.types import BackgroundTask, Node, build_node_from_peer_name
+
+
+@dataclass(slots=True)
+class EndpointMetadata:
+    name: str
+    publish: bool = True
+    description: str = ""
 
 
 class Server:
@@ -25,10 +33,12 @@ class Server:
         self.address = address
         self.port = port
         self.endpoint_directory: dict[str, Callable] = {}
+        self.endpoint_metadata: dict[str, EndpointMetadata] = {}
         self.max_upload_size = max_upload_size
         self.background_executor = BackgroundTaskHandler()
         self.serializer_class = serializer_class
         self._server: asyncio.Server | None = None
+        self._register_system_endpoints()
 
     def run(self) -> None:
         """Run the server."""
@@ -126,11 +136,36 @@ class Server:
         finally:
             await self.stop()
 
-    def endpoint(self, name: str | None = None) -> Callable:
+    def _register_system_endpoints(self) -> None:
+        @self.endpoint("_synapse.ping", publish=False)
+        async def ping() -> str:
+            return "pong"
+
+        @self.endpoint("_synapse.methods", publish=False)
+        async def methods() -> list[dict[str, str | bool]]:
+            return [
+                asdict(metadata)
+                for metadata in self.endpoint_metadata.values()
+                if metadata.publish
+            ]
+
+    def endpoint(
+        self,
+        name: str | None = None,
+        *,
+        publish: bool = True,
+        description: str = "",
+    ) -> Callable:
         """Decorator to register a coroutine as an RPC endpoint."""
 
         def decorator(wrapped: Callable) -> Callable:
-            self.endpoint_directory[name or wrapped.__name__] = wrapped
+            endpoint_name = name or wrapped.__name__
+            self.endpoint_directory[endpoint_name] = wrapped
+            self.endpoint_metadata[endpoint_name] = EndpointMetadata(
+                name=endpoint_name,
+                publish=publish,
+                description=description or inspect.getdoc(wrapped) or "",
+            )
             return wrapped
 
         return decorator

--- a/synapse_p2p/tests/test_agent.py
+++ b/synapse_p2p/tests/test_agent.py
@@ -1,0 +1,86 @@
+
+import pytest
+
+from synapse_p2p import AgentCapability, AgentNode, Client
+
+
+@pytest.mark.asyncio
+async def test_agent_info_and_capabilities_are_discoverable():
+    agent = AgentNode(
+        name="Reviewer",
+        role="reviewer",
+        description="Reviews Python code",
+        capabilities=[
+            "python",
+            AgentCapability(name="code-review", description="Review code for quality"),
+        ],
+        address="127.0.0.1",
+        port=0,
+    )
+
+    server = await agent.start()
+    host, port = server.sockets[0].getsockname()[:2]
+
+    try:
+        client = Client(host, port)
+        assert await client.call("_agent.info") == {
+            "name": "Reviewer",
+            "role": "reviewer",
+            "description": "Reviews Python code",
+            "capabilities": ["python", "code-review"],
+        }
+        assert await client.call("_agent.capabilities") == [
+            {"name": "python", "description": "", "input_schema": {}, "output_schema": {}},
+            {
+                "name": "code-review",
+                "description": "Review code for quality",
+                "input_schema": {},
+                "output_schema": {},
+            },
+        ]
+    finally:
+        await agent.stop()
+
+
+@pytest.mark.asyncio
+async def test_agent_ask_delegates_to_task_handler():
+    agent = AgentNode(name="Coder", role="coder", capabilities=["python"], port=0)
+
+    @agent.task_handler
+    async def handle_task(task: str, context: dict):
+        return {"task": task, "language": context["language"]}
+
+    server = await agent.start()
+    host, port = server.sockets[0].getsockname()[:2]
+
+    try:
+        result = await Client(host, port).call(
+            "_agent.ask", "write a test", context={"language": "python"}
+        )
+        assert result == {"task": "write a test", "language": "python"}
+    finally:
+        await agent.stop()
+
+
+@pytest.mark.asyncio
+async def test_published_methods_excludes_private_system_and_agent_endpoints():
+    agent = AgentNode(name="Coder", role="coder", port=0)
+
+    @agent.endpoint("public.tool", description="A public tool")
+    async def public_tool():
+        return "ok"
+
+    @agent.endpoint("private.tool", publish=False)
+    async def private_tool():
+        return "hidden"
+
+    server = await agent.start()
+    host, port = server.sockets[0].getsockname()[:2]
+
+    try:
+        methods = await Client(host, port).call("_synapse.methods")
+        assert isinstance(methods, list)
+        assert {method["name"] for method in methods} == {"public.tool"}
+        assert methods[0]["description"] == "A public tool"
+    finally:
+        await agent.stop()


### PR DESCRIPTION
- Add AgentNode and AgentCapability abstractions
- Expose built-in agent metadata endpoints
- Add _agent.info, _agent.capabilities, and _agent.ask
- Add published method discovery via _synapse.methods
- Support public/private endpoint metadata
- Update README and package description for agentic workflows
- Document LLM-agent discovery, delegation, and tool publishing patterns
- Add tests for agent metadata, task delegation, and method discovery